### PR TITLE
Allowing installation of plugin from PHP 7.2+ (incl 8.0)

### DIFF
--- a/buddy.yml
+++ b/buddy.yml
@@ -55,3 +55,20 @@
             - "/:/buddy/composer-plugin"
         trigger_condition: "ALWAYS"
         shell: "BASH"
+      - action: "PHP 8.0"
+        type: "BUILD"
+        working_directory: "/buddy/composer-plugin"
+        docker_image_name: "library/php"
+        docker_image_tag: "8.0"
+        execute_commands:
+            - "composer validate"
+            - "composer update"
+            - "composer tests"
+        setup_commands:
+            - "echo \"memory_limit=-1\" >> /usr/local/etc/php/conf.d/buddy.ini"
+            - "apt-get update && apt-get install -y git zip"
+            - "curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer"
+        volume_mappings:
+            - "/:/buddy/composer-plugin"
+        trigger_condition: "ALWAYS"
+        shell: "BASH"

--- a/buddy.yml
+++ b/buddy.yml
@@ -63,6 +63,7 @@
         execute_commands:
             - "composer validate"
             - "composer update"
+            - rm -rf tests-plugin/composer.lock tests-plugin/vendor
             - "composer tests"
         setup_commands:
             - "echo \"memory_limit=-1\" >> /usr/local/etc/php/conf.d/buddy.ini"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
             "@check-cs",
             "@phpstan",
             "@phpunit",
-            "cd tests-plugin && composer install"
+            "cd tests-plugin && composer install --ignore-platform-reqs"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2.0",
         "composer-plugin-api": "^2.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ca1863c5c3bd1f82cf2ca71cbf53df3",
+    "content-hash": "03c253c19dc791e6f13f5316097ccdd8",
     "packages": [],
     "packages-dev": [
         {
@@ -4136,12 +4136,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -4179,8 +4179,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         }
@@ -4191,7 +4191,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": ">=7.2.0",
         "composer-plugin-api": "^2.0"
     },
     "platform-dev": [],


### PR DESCRIPTION
Closes #11 

I added a small hack for the installation test of the plugin:

I added:
```
--ignore-platform-reqs
```

Which we will have to take out after this MR is done. I had to do this, for the test to pass on PHP 8 (because the test is referencing `dev-master`).