### PR TITLE
Using int for priority in event subscriber - Avoid PHP 8 Runtime exception

### DIFF
--- a/src/Repman.php
+++ b/src/Repman.php
@@ -16,7 +16,10 @@ use Composer\Plugin\PluginInterface;
 
 final class Repman implements PluginInterface, EventSubscriberInterface
 {
+    /** @var string */
     public const VERSION = '1.1.0';
+
+    /** @var string */
     public const DEFAULT_BASE_URL = 'https://repo.repman.io';
 
     /**
@@ -41,7 +44,7 @@ final class Repman implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return [InstallerEvents::PRE_OPERATIONS_EXEC => ['populateMirrors', '9'.PHP_INT_MAX]];
+        return [InstallerEvents::PRE_OPERATIONS_EXEC => ['populateMirrors', PHP_INT_MAX]];
     }
 
     public function populateMirrors(InstallerEvent $installerEvent): void


### PR DESCRIPTION
Due to the new way PHP handles arrays in `call_user_func_array()`( [check here](https://bugs.php.net/bug.php?id=80531) ) when passing the priority as string instead of int, PHP will throw an Error saying that "Cannot use positional argument after named argument" inside composer code.

I tracked down the error and you can see it on this screenshot: 
![image](https://user-images.githubusercontent.com/2609731/111647222-98373880-8802-11eb-8d8c-eea9c2af14e7.png)

The full stack trace in other project:
![image](https://user-images.githubusercontent.com/2609731/111649271-8060b400-8804-11eb-9930-2b154b973514.png)


I don't know the rationale behind prepending that `'9'`, but it simply won't work on PHP 8. I hope if we leave it like that is still okay.


If you guys are interested in a minimal script to test the behavior it would go like this:

```php
<?php

call_user_func_array('array_merge', ['9'.PHP_INT_MAX => [[new stdClass(), 'someString']],  0 => []]);

// casting '9'.PHP_INT_MAX to (int) won't cut it as well, since PHP will transform it back to string 
// because it cant represent it as int.

var_dump(is_string((int)'9'.PHP_INT_MAX)); // => bool(true)


```